### PR TITLE
Fix jessie backports workaround

### DIFF
--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -1,28 +1,25 @@
 ---
 
-- name: Add backports repository for Jessie release
-  apt_repository: repo="deb http://ftp.debian.org/debian stretch-backports main" state=present
-  when: ansible_os_family == "Debian" and ansible_distribution_release == "stretch"
+- block:
+    # for legacy compatibility, because ftp.debian.org backports is not available anymore
+    - name: Remove the non-working backports repository for Jessie release
+      lineinfile:
+        path: /etc/apt/sources.list.d/ftp_debian_org_debian.list
+        state: absent
+        regexp: '.*ftp.debian.org/debian jessie-backports.*'
 
-# Because backports is not available anymore
-- name: Add stretch repository for Jessie release
-  apt_repository:
-    repo: deb-src deb http://ftp.debian.org/debian stretch main
-    state: present
+    - name: Bypass jessie-backports InRelease expiration
+      copy:
+        content: 'Acquire::Check-Valid-Until "false";'
+        dest: /etc/apt/apt.conf.d/99cycloid-sphinx-check-valid-until
+
+    - name: Add archive backports repository for Jessie release
+      apt_repository:
+        repo: "deb http://archive.debian.org/debian jessie-backports main"
+        state: present
   tags:
     - sphinx-apt
   when: ansible_os_family == "Debian" and ansible_distribution_release == "jessie"
-
-- name: set stretch* priority
-  copy:
-    content: |
-      Package: *
-      Pin: release o=Debian,n=stretch
-      Pin-Priority: 100
-    dest: /etc/apt/preferences.d/stretch.pref
-  tags:
-    - sphinx-apt
-   when: ansible_os_family == "Debian" and ansible_distribution_release == "jessie"
 
 - name: Install sphinx Debian package
   apt: name={{ item }} state=present update_cache=yes


### PR DESCRIPTION
* stretch backports in not necessary for sphinxsearch package
* Make sure to remove the old jessie-backports repository, for smooth
transition
* Use the archive apt repository for jessie-backports + bypass the
InRelease expiration